### PR TITLE
Remove sqlcommenter dependency from the WebFlux example project.

### DIFF
--- a/spring-boot-r2dbc/build.gradle.kts
+++ b/spring-boot-r2dbc/build.gradle.kts
@@ -21,7 +21,6 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.komapper:komapper-spring-boot-starter-r2dbc:$komapperVersion")
-    implementation("org.komapper:komapper-sqlcommenter:$komapperVersion")
     implementation("org.komapper:komapper-dialect-h2-r2dbc:$komapperVersion")
     ksp("org.komapper:komapper-processor:$komapperVersion")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/spring-boot-r2dbc/src/main/kotlin/org/komapper/example/WebConfig.kt
+++ b/spring-boot-r2dbc/src/main/kotlin/org/komapper/example/WebConfig.kt
@@ -1,26 +1,9 @@
 package org.komapper.example
 
-import com.google.cloud.sqlcommenter.interceptors.SpringSQLCommenterInterceptor
-import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.web.servlet.config.annotation.EnableWebMvc
-import org.springframework.web.servlet.config.annotation.InterceptorRegistry
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import org.springframework.web.reactive.config.EnableWebFlux
+import org.springframework.web.reactive.config.WebFluxConfigurer
 
-/**
- * This configuration is optional.
- * See also https://github.com/google/sqlcommenter/tree/master/java/sqlcommenter-java#spring
- */
-@EnableWebMvc
+@EnableWebFlux
 @Configuration
-class WebConfig : WebMvcConfigurer {
-
-    @Bean
-    fun sqlInterceptor(): SpringSQLCommenterInterceptor {
-        return SpringSQLCommenterInterceptor()
-    }
-
-    override fun addInterceptors(registry: InterceptorRegistry) {
-        registry.addInterceptor(sqlInterceptor())
-    }
-}
+class WebConfig : WebFluxConfigurer


### PR DESCRIPTION
Because sqlcommenter depends on Web MVC.