### PR TITLE
Download Spring releases from Maven Central.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,8 +30,6 @@ allprojects {
     repositories {
         mavenLocal()
         mavenCentral()
-        maven { url = uri("https://repo.spring.io/release") }
-        maven { url = uri("https://repo.spring.io/milestone") }
     }
 
     tasks {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,8 +1,6 @@
 pluginManagement {
     repositories {
         mavenLocal()
-        maven { url = uri("https://repo.spring.io/release") }
-        maven { url = uri("https://repo.spring.io/milestone") }
         gradlePluginPortal()
         mavenCentral()
     }


### PR DESCRIPTION
See https://spring.io/blog/2022/12/14/notice-of-permissions-changes-to-repo-spring-io-january-2023