### PR TITLE
Add example tests for Spring Boot test slices

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 junit = "5.11.3"
-komapper = "5.0.0"
+komapper = "5.0.1-SNAPSHOT"
 kotlin = "2.1.0"
 ksp = "2.1.0-1.0.29"
 quarkus = "3.17.2"
@@ -17,6 +17,7 @@ komapper-starter-jdbc = { module = "org.komapper:komapper-starter-jdbc" }
 komapper-starter-r2dbc = { module = "org.komapper:komapper-starter-r2dbc" }
 komapper-spring-boot-starter-jdbc = { module = "org.komapper:komapper-spring-boot-starter-jdbc" }
 komapper-spring-boot-starter-r2dbc = { module = "org.komapper:komapper-spring-boot-starter-r2dbc" }
+komapper-spring-boot-starter-test-jdbc = { module = "org.komapper:komapper-spring-boot-starter-test-jdbc" }
 
 spring-boot-devtools = { module = "org.springframework.boot:spring-boot-devtools" }
 spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-starter-security" }

--- a/jpetstore/build.gradle.kts
+++ b/jpetstore/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     testImplementation(libs.spring.boot.starter.test) {
         exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
     }
+    testImplementation(libs.komapper.spring.boot.starter.test.jdbc)
 }
 
 tasks {

--- a/jpetstore/src/main/kotlin/org/komapper/example/model/AccountAggregate.kt
+++ b/jpetstore/src/main/kotlin/org/komapper/example/model/AccountAggregate.kt
@@ -4,7 +4,7 @@ import org.komapper.example.entity.Account
 import org.komapper.example.entity.Profile
 import org.komapper.example.entity.SignOn
 
-class AccountAggregate(
+data class AccountAggregate(
     val account: Account,
     val profile: Profile,
     val signOn: SignOn,

--- a/jpetstore/src/main/kotlin/org/komapper/example/model/ItemAggregate.kt
+++ b/jpetstore/src/main/kotlin/org/komapper/example/model/ItemAggregate.kt
@@ -4,7 +4,7 @@ import org.komapper.example.entity.Inventory
 import org.komapper.example.entity.Item
 import org.komapper.example.entity.Product
 
-class ItemAggregate(
+data class ItemAggregate(
     val item: Item,
     val inventory: Inventory,
     val product: Product,

--- a/jpetstore/src/main/kotlin/org/komapper/example/model/OrderAggregate.kt
+++ b/jpetstore/src/main/kotlin/org/komapper/example/model/OrderAggregate.kt
@@ -5,7 +5,7 @@ import org.komapper.example.entity.Order
 import org.komapper.example.entity.OrderStatus
 import org.komapper.example.entity.Product
 
-class OrderAggregate(
+data class OrderAggregate(
     val order: Order,
     val orderStatus: OrderStatus,
     val lineItemSet: Set<LineItem>,

--- a/jpetstore/src/main/kotlin/org/komapper/example/model/ProductAggregate.kt
+++ b/jpetstore/src/main/kotlin/org/komapper/example/model/ProductAggregate.kt
@@ -3,7 +3,7 @@ package org.komapper.example.model
 import org.komapper.example.entity.Item
 import org.komapper.example.entity.Product
 
-class ProductAggregate(
+data class ProductAggregate(
     val product: Product,
     val itemSet: Set<Item>,
 )

--- a/jpetstore/src/test/kotlin/org/komapper/example/repository/AccountRepositoryTest.kt
+++ b/jpetstore/src/test/kotlin/org/komapper/example/repository/AccountRepositoryTest.kt
@@ -1,0 +1,156 @@
+package org.komapper.example.repository
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.core.dsl.query.singleOrNull
+import org.komapper.example.entity.Account
+import org.komapper.example.entity.Profile
+import org.komapper.example.entity.SignOn
+import org.komapper.example.entity.account
+import org.komapper.example.entity.profile
+import org.komapper.example.entity.signOn
+import org.komapper.example.model.AccountAggregate
+import org.komapper.jdbc.JdbcDatabase
+import org.komapper.spring.boot.test.autoconfigure.jdbc.KomapperJdbcTest
+import org.springframework.beans.factory.annotation.Autowired
+
+@KomapperJdbcTest
+class AccountRepositoryTest(
+    @Autowired
+    private val accountRepository: AccountRepository,
+    @Autowired
+    private val db: JdbcDatabase,
+) {
+    @Test
+    fun fetchAccountAggregate() {
+        assertThat(accountRepository.fetchAccountAggregate("komapper")).isEqualTo(
+            AccountAggregate(
+                Account(
+                    username = "komapper",
+                    email = "komapper@yourdomain.com",
+                    firstName = "ABC",
+                    lastName = "XYX",
+                    status = "OK",
+                    address1 = "901 San Antonio Road",
+                    address2 = "MS UCUP02-206",
+                    city = "Palo Alto",
+                    state = "CA",
+                    zip = "94303",
+                    country = "USA",
+                    phone = "555-555-5555",
+                ),
+                Profile(
+                    username = "komapper",
+                    languagePreference = "english",
+                    favouriteCategoryId = "DOGS",
+                    listOption = 1,
+                    bannerOption = 1,
+                ),
+                SignOn(
+                    username = "komapper",
+                    password = "\$2a\$10\$rEpBZe1kO3VxlUq.rHs1Auo.QlSo4pzNpcLkuE92ss4oT76r35XHe",
+                ),
+            )
+        )
+    }
+
+    @Test
+    fun insertAccount() {
+        val account = Account(
+            username = "komapper01",
+            email = "komapper01@komapper.org",
+            firstName = "Komapper",
+            lastName = "01",
+            status = "!!",
+            address1 = "Line#1",
+            address2 = "line#2",
+            city = "City",
+            state = "CA",
+            zip = "90000",
+            country = "USA",
+            phone = "111-222-3333",
+        )
+
+        accountRepository.insertAccount(account)
+
+        val query = QueryDsl.from(Meta.account).where { Meta.account.username eq "komapper01" }
+        assertThat(db.runQuery(query)).containsExactly(account)
+    }
+
+    @Test
+    fun insertProfile() {
+        val profile = Profile(
+            username = "komapper01",
+            languagePreference = "spanish",
+            favouriteCategoryId = "BIRDS",
+            listOption = 1,
+            bannerOption = 0,
+        )
+
+        accountRepository.insertProfile(profile)
+
+        val query = QueryDsl.from(Meta.profile).where { Meta.profile.username eq "komapper01" }
+        assertThat(db.runQuery(query)).containsExactly(profile)
+    }
+
+    @Test
+    fun insertSignOn() {
+        val signOn = SignOn("username", "password")
+
+        accountRepository.insertSignOn(signOn)
+
+        val query = QueryDsl.from(Meta.signOn).where { Meta.signOn.username eq "username" }
+        assertThat(db.runQuery(query)).containsExactly(signOn)
+    }
+
+    @Test
+    fun updateAccount() {
+        val query = QueryDsl.from(Meta.account)
+            .where { Meta.account.username eq "komapper" }
+            .select(Meta.account.phone)
+            .singleOrNull()
+        assertThat(db.runQuery(query)).isEqualTo("555-555-5555")
+
+        val account = Account(
+            username = "komapper",
+            email = "komapper@yourdomain.com",
+            firstName = "ABC",
+            lastName = "XYX",
+            status = "OK",
+            address1 = "901 San Antonio Road",
+            address2 = "MS UCUP02-206",
+            city = "Palo Alto",
+            state = "CA",
+            zip = "94303",
+            country = "USA",
+            phone = "888-888-8888",
+        )
+
+        accountRepository.updateAccount(account)
+
+        assertThat(db.runQuery(query)).isEqualTo("888-888-8888")
+    }
+
+    @Test
+    fun updateProfile() {
+        val query = QueryDsl.from(Meta.profile)
+            .where { Meta.profile.username eq "komapper" }
+            .select(Meta.profile.favouriteCategoryId)
+            .singleOrNull()
+        assertThat(db.runQuery(query)).isEqualTo("DOGS")
+
+        val profile = Profile(
+            username = "komapper",
+            languagePreference = "english",
+            favouriteCategoryId = "CATS",
+            listOption = 1,
+            bannerOption = 1,
+        )
+
+        accountRepository.updateProfile(profile)
+
+        assertThat(db.runQuery(query)).isEqualTo("CATS")
+    }
+}

--- a/jpetstore/src/test/kotlin/org/komapper/example/repository/AccountRepositoryTest.kt
+++ b/jpetstore/src/test/kotlin/org/komapper/example/repository/AccountRepositoryTest.kt
@@ -15,8 +15,10 @@ import org.komapper.example.model.AccountAggregate
 import org.komapper.jdbc.JdbcDatabase
 import org.komapper.spring.boot.test.autoconfigure.jdbc.KomapperJdbcTest
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 
 @KomapperJdbcTest
+@AutoConfigureTestDatabase
 class AccountRepositoryTest(
     @Autowired
     private val accountRepository: AccountRepository,

--- a/jpetstore/src/test/kotlin/org/komapper/example/repository/CategoryRepositoryTest.kt
+++ b/jpetstore/src/test/kotlin/org/komapper/example/repository/CategoryRepositoryTest.kt
@@ -5,8 +5,10 @@ import org.junit.jupiter.api.Test
 import org.komapper.example.entity.Category
 import org.komapper.spring.boot.test.autoconfigure.jdbc.KomapperJdbcTest
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 
 @KomapperJdbcTest
+@AutoConfigureTestDatabase
 class CategoryRepositoryTest(
     @Autowired
     private val categoryRepository: CategoryRepository,

--- a/jpetstore/src/test/kotlin/org/komapper/example/repository/CategoryRepositoryTest.kt
+++ b/jpetstore/src/test/kotlin/org/komapper/example/repository/CategoryRepositoryTest.kt
@@ -1,0 +1,24 @@
+package org.komapper.example.repository
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.komapper.example.entity.Category
+import org.komapper.spring.boot.test.autoconfigure.jdbc.KomapperJdbcTest
+import org.springframework.beans.factory.annotation.Autowired
+
+@KomapperJdbcTest
+class CategoryRepositoryTest(
+    @Autowired
+    private val categoryRepository: CategoryRepository,
+) {
+    @Test
+    fun fetchCategory() {
+        assertThat(categoryRepository.fetchCategory("BIRDS")).isEqualTo(
+            Category(
+                categoryId = "BIRDS",
+                name = "Birds",
+                description = """<image src="/images/birds_icon.gif"><font size="5" color="blue"> Birds</font>""",
+            )
+        )
+    }
+}

--- a/jpetstore/src/test/kotlin/org/komapper/example/repository/ItemRepositoryTest.kt
+++ b/jpetstore/src/test/kotlin/org/komapper/example/repository/ItemRepositoryTest.kt
@@ -1,0 +1,47 @@
+package org.komapper.example.repository
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.komapper.example.entity.Inventory
+import org.komapper.example.entity.Item
+import org.komapper.example.entity.Product
+import org.komapper.example.model.ItemAggregate
+import org.komapper.spring.boot.test.autoconfigure.jdbc.KomapperJdbcTest
+import org.springframework.beans.factory.annotation.Autowired
+
+@KomapperJdbcTest
+class ItemRepositoryTest(
+    @Autowired
+    private val itemRepository: ItemRepository,
+) {
+    @Test
+    fun fetchItemAggregate() {
+        assertThat(itemRepository.fetchItemAggregate("EST-1")).isEqualTo(
+            ItemAggregate(
+                Item(
+                    itemId = "EST-1",
+                    productId = "FI-SW-01",
+                    listPrice = "16.50".toBigDecimal(),
+                    unitCost = "10.00".toBigDecimal(),
+                    supplierId = 1,
+                    status = "P",
+                    attribute1 = "Large",
+                    attribute2 = null,
+                    attribute3 = null,
+                    attribute4 = null,
+                    attribute5 = null,
+                ),
+                Inventory(
+                    itemId = "EST-1",
+                    quantity = 10000,
+                ),
+                Product(
+                    productId = "FI-SW-01",
+                    categoryId = "FISH",
+                    name = "Angelfish",
+                    description = """<image src="/images/fish1.gif">Salt Water fish from Australia""",
+                )
+            )
+        )
+    }
+}

--- a/jpetstore/src/test/kotlin/org/komapper/example/repository/ItemRepositoryTest.kt
+++ b/jpetstore/src/test/kotlin/org/komapper/example/repository/ItemRepositoryTest.kt
@@ -8,8 +8,10 @@ import org.komapper.example.entity.Product
 import org.komapper.example.model.ItemAggregate
 import org.komapper.spring.boot.test.autoconfigure.jdbc.KomapperJdbcTest
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 
 @KomapperJdbcTest
+@AutoConfigureTestDatabase
 class ItemRepositoryTest(
     @Autowired
     private val itemRepository: ItemRepository,

--- a/jpetstore/src/test/kotlin/org/komapper/example/repository/OrderRepositoryTest.kt
+++ b/jpetstore/src/test/kotlin/org/komapper/example/repository/OrderRepositoryTest.kt
@@ -1,8 +1,5 @@
 package org.komapper.example.repository
 
-import java.math.BigDecimal
-import java.time.LocalDate
-import java.time.LocalDateTime
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.komapper.core.dsl.Meta
@@ -17,7 +14,9 @@ import org.komapper.example.model.OrderAggregate
 import org.komapper.jdbc.JdbcDatabase
 import org.komapper.spring.boot.test.autoconfigure.jdbc.KomapperJdbcTest
 import org.springframework.beans.factory.annotation.Autowired
-
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 @KomapperJdbcTest
 class OrderRepositoryTest(

--- a/jpetstore/src/test/kotlin/org/komapper/example/repository/OrderRepositoryTest.kt
+++ b/jpetstore/src/test/kotlin/org/komapper/example/repository/OrderRepositoryTest.kt
@@ -1,0 +1,178 @@
+package org.komapper.example.repository
+
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.komapper.core.dsl.Meta
+import org.komapper.core.dsl.QueryDsl
+import org.komapper.example.entity.LineItem
+import org.komapper.example.entity.Order
+import org.komapper.example.entity.OrderStatus
+import org.komapper.example.entity.Product
+import org.komapper.example.entity.order
+import org.komapper.example.entity.orderStatus
+import org.komapper.example.model.OrderAggregate
+import org.komapper.jdbc.JdbcDatabase
+import org.komapper.spring.boot.test.autoconfigure.jdbc.KomapperJdbcTest
+import org.springframework.beans.factory.annotation.Autowired
+
+
+@KomapperJdbcTest
+class OrderRepositoryTest(
+    @Autowired
+    private val orderRepository: OrderRepository,
+    @Autowired
+    private val db: JdbcDatabase,
+) {
+    @Test
+    fun insertOrder() {
+        val order = Order(
+            orderDate = LocalDateTime.of(2018, 12, 31, 23, 59, 59),
+            username = "komapper",
+            cardType = "Visa",
+            creditCard = "1234 5678 9012 3456",
+            expiryDate = "06/2022",
+            courier = "Courier",
+            locale = "ja",
+            totalPrice = "2000.05".toBigDecimal(),
+            billAddress1 = "Bill Address1",
+            billAddress2 = "Bill Address2",
+            billCity = "Bill City",
+            billState = "Bill State",
+            billCountry = "USA",
+            billZip = "80001",
+            billToFirstName = "Bill First Name",
+            billToLastName = "Bill Last Name",
+            shipAddress1 = "Ship Address1",
+            shipAddress2 = "Ship Address2",
+            shipCity = "Ship City",
+            shipState = "Ship State",
+            shipCountry = "JPN",
+            shipZip = "70001",
+            shipToFirstName = "Ship First Name",
+            shipToLastName = "Ship Last Name",
+        )
+
+        val orderId = orderRepository.insertOrder(order).orderId
+
+        val query = QueryDsl.from(Meta.order).where { Meta.order.orderId eq orderId }
+        assertThat(db.runQuery(query)).containsExactly(order.copy(orderId = orderId))
+    }
+
+    @Test
+    fun insertOrderStatusList() {
+        val orderStatus = OrderStatus(
+            orderId = 1,
+            lineNumber = 1,
+            timestamp = LocalDate.of(2018, 12, 31),
+            status = "OK",
+        )
+
+        orderRepository.insertOrderStatusList(listOf(orderStatus))
+
+        val query = QueryDsl.from(Meta.orderStatus).where { Meta.orderStatus.orderId eq 1 }
+        assertThat(db.runQuery(query)).containsExactly(orderStatus)
+    }
+
+    @Test
+    fun fetchOrderList() {
+        val newOrder = Order(
+            orderDate = LocalDateTime.of(2018, 12, 31, 23, 59, 59),
+            username = "komapper",
+            cardType = "Visa",
+            creditCard = "1234 5678 9012 3456",
+            expiryDate = "06/2022",
+            courier = "Courier",
+            locale = "ja",
+            totalPrice = "2000.05".toBigDecimal(),
+            billAddress1 = "Bill Address1",
+            billAddress2 = "Bill Address2",
+            billCity = "Bill City",
+            billState = "Bill State",
+            billCountry = "USA",
+            billZip = "80001",
+            billToFirstName = "Bill First Name",
+            billToLastName = "Bill Last Name",
+            shipAddress1 = "Ship Address1",
+            shipAddress2 = "Ship Address2",
+            shipCity = "Ship City",
+            shipState = "Ship State",
+            shipCountry = "JPN",
+            shipZip = "70001",
+            shipToFirstName = "Ship First Name",
+            shipToLastName = "Ship Last Name"
+        )
+        val orderId = orderRepository.insertOrder(newOrder).orderId
+
+        assertThat(orderRepository.fetchOrderList("komapper")).containsExactly(newOrder.copy(orderId = orderId))
+    }
+
+    @Test
+    fun fetchOrderAggregate() {
+        val order = Order(
+            orderDate = LocalDateTime.of(2018, 12, 31, 23, 59, 59),
+            username = "j2ee",
+            cardType = "Visa",
+            creditCard = "1234 5678 9012 3456",
+            expiryDate = "06/2022",
+            courier = "Courier",
+            locale = "ja",
+            totalPrice = BigDecimal("2000.05"),
+            billAddress1 = "Bill Address1",
+            billAddress2 = "Bill Address2",
+            billCity = "Bill City",
+            billState = "Bill State",
+            billCountry = "USA",
+            billZip = "80001",
+            billToFirstName = "Bill First Name",
+            billToLastName = "Bill Last Name",
+            shipAddress1 = "Ship Address1",
+            shipAddress2 = "Ship Address2",
+            shipCity = "Ship City",
+            shipState = "Ship State",
+            shipCountry = "JPN",
+            shipZip = "70001",
+            shipToFirstName = "Ship First Name",
+            shipToLastName = "Ship Last Name",
+        )
+        val orderId = orderRepository.insertOrder(order).orderId
+
+        val orderLine = LineItem(
+            orderId = orderId,
+            lineNumber = 1,
+            itemId = "EST-7",
+            quantity = 2,
+            unitPrice = "14.00".toBigDecimal(),
+        )
+        orderRepository.insertLineItemList(listOf(orderLine))
+
+        val orderStatus = OrderStatus(
+            orderId = orderId,
+            lineNumber = 1,
+            timestamp = LocalDate.of(2018, 12, 31),
+            status = "OK",
+        )
+        orderRepository.insertOrderStatusList(listOf(orderStatus))
+
+        val orderAggregate = orderRepository.fetchOrderAggregate(orderId)
+        assertThat(orderAggregate)
+            .isNotNull()
+            .isEqualTo(
+                OrderAggregate(
+                    order = order.copy(orderId = orderId),
+                    orderStatus = orderStatus,
+                    lineItemSet = setOf(orderLine),
+                    lineItem_product = mapOf(
+                        orderLine to Product(
+                            productId = "K9-BD-01",
+                            categoryId = "DOGS",
+                            name = "Bulldog",
+                            description = """<image src="/images/dog2.gif">Friendly dog from England""",
+                        ),
+                    ),
+                )
+            )
+    }
+}

--- a/jpetstore/src/test/kotlin/org/komapper/example/repository/OrderRepositoryTest.kt
+++ b/jpetstore/src/test/kotlin/org/komapper/example/repository/OrderRepositoryTest.kt
@@ -14,11 +14,13 @@ import org.komapper.example.model.OrderAggregate
 import org.komapper.jdbc.JdbcDatabase
 import org.komapper.spring.boot.test.autoconfigure.jdbc.KomapperJdbcTest
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
 
 @KomapperJdbcTest
+@AutoConfigureTestDatabase
 class OrderRepositoryTest(
     @Autowired
     private val orderRepository: OrderRepository,

--- a/jpetstore/src/test/kotlin/org/komapper/example/repository/ProductRepositoryTest.kt
+++ b/jpetstore/src/test/kotlin/org/komapper/example/repository/ProductRepositoryTest.kt
@@ -7,8 +7,10 @@ import org.komapper.example.entity.Product
 import org.komapper.example.model.ProductAggregate
 import org.komapper.spring.boot.test.autoconfigure.jdbc.KomapperJdbcTest
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 
 @KomapperJdbcTest
+@AutoConfigureTestDatabase
 class ProductRepositoryTest(
     @Autowired
     private val productRepository: ProductRepository,

--- a/jpetstore/src/test/kotlin/org/komapper/example/repository/ProductRepositoryTest.kt
+++ b/jpetstore/src/test/kotlin/org/komapper/example/repository/ProductRepositoryTest.kt
@@ -1,0 +1,97 @@
+package org.komapper.example.repository
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.komapper.example.entity.Item
+import org.komapper.example.entity.Product
+import org.komapper.example.model.ProductAggregate
+import org.komapper.spring.boot.test.autoconfigure.jdbc.KomapperJdbcTest
+import org.springframework.beans.factory.annotation.Autowired
+
+@KomapperJdbcTest
+class ProductRepositoryTest(
+    @Autowired
+    private val productRepository: ProductRepository,
+) {
+    @Test
+    fun fetchProductListByCategoryId() {
+        assertThat(productRepository.fetchProductListByCategoryId("FISH")).containsExactlyInAnyOrder(
+            Product(
+                productId = "FI-FW-01",
+                categoryId = "FISH",
+                name = "Koi",
+                description = """<image src="/images/fish3.gif">Fresh Water fish from Japan""",
+            ),
+            Product(
+                productId = "FI-FW-02",
+                categoryId = "FISH",
+                name = "Goldfish",
+                description = """<image src="/images/fish2.gif">Fresh Water fish from China""",
+            ),
+            Product(
+                productId = "FI-SW-01",
+                categoryId = "FISH",
+                name = "Angelfish",
+                description = """<image src="/images/fish1.gif">Salt Water fish from Australia""",
+            ),
+            Product(
+                productId = "FI-SW-02",
+                categoryId = "FISH",
+                name = "Tiger Shark",
+                description = """<image src="/images/fish4.gif">Salt Water fish from Australia""",
+            ),
+        )
+    }
+
+    @Test
+    fun fetchProductAggregate() {
+        assertThat(productRepository.fetchProductAggregate("FI-FW-01")).isEqualTo(
+            ProductAggregate(
+                Product(
+                    productId = "FI-FW-01",
+                    name = "Koi",
+                    categoryId = "FISH",
+                    description = """<image src="/images/fish3.gif">Fresh Water fish from Japan""",
+                ),
+                setOf(
+                    Item(
+                        itemId = "EST-4",
+                        productId = "FI-FW-01",
+                        listPrice = "18.50".toBigDecimal(),
+                        unitCost = "12.00".toBigDecimal(),
+                        supplierId = 1,
+                        status = "P",
+                        attribute1 = "Spotted",
+                        attribute2 = null,
+                        attribute3 = null,
+                        attribute4 = null,
+                        attribute5 = null,
+                    ),
+                    Item(
+                        itemId = "EST-5",
+                        productId = "FI-FW-01",
+                        listPrice = "18.50".toBigDecimal(),
+                        unitCost = "12.00".toBigDecimal(),
+                        supplierId = 1,
+                        status = "P",
+                        attribute1 = "Spotless",
+                        attribute2 = null,
+                        attribute3 = null,
+                        attribute4 = null,
+                        attribute5 = null,
+                    ),
+                ),
+            )
+        )
+    }
+
+    @Test
+    fun fetchProductListByKeywords() {
+        val products = productRepository.fetchProductListByKeywords(listOf("ol"))
+        assertThat(products.map { it.name })
+            .containsExactlyInAnyOrder(
+                "Goldfish",
+                "Golden Retriever",
+            )
+    }
+}

--- a/jpetstore/src/test/resources/META-INF/spring/org.komapper.spring.boot.test.autoconfigure.jdbc.AutoConfigureKomapperJdbc.imports
+++ b/jpetstore/src/test/resources/META-INF/spring/org.komapper.spring.boot.test.autoconfigure.jdbc.AutoConfigureKomapperJdbc.imports
@@ -1,0 +1,6 @@
+# List of "Komapper-related" beans to be loaded by @KomapperJdbcTest/@AutoConfigureKomapperJdbc
+org.komapper.example.repository.AccountRepository
+org.komapper.example.repository.CategoryRepository
+org.komapper.example.repository.ItemRepository
+org.komapper.example.repository.OrderRepository
+org.komapper.example.repository.ProductRepository


### PR DESCRIPTION
Illustrate Komapper Spring Boot test slices (`@KomapperJdbcTest`) with tests for the `jpetstore` application. Tests are ported from the [MyBatis jpetstore-6 example](https://github.com/mybatis/jpetstore-6/tree/6140075181b71aabc20594f4a609910861c4e7bf/src/test/java/org/mybatis/jpetstore/mapper).

Tests illustrate how:
1. `@KomapperJdbcTest` works similarly to `@SpringBootTest` or its native test slices like `@DataJdbcTest`.
2. Custom beans (e.g. repositories) can be added to the slice to automatically load.
3. Both Komapper beans (`JdbcDatabase`) and custom repositories can be injected into `@KomapperJdbcTest` tests.

TODO
- [x] Update Komapper version when the next version is released.