### PR TITLE
Improve Gradle build performance

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,11 @@
 kotlin.code.style=official
-org.gradle.jvmargs=-Xmx2560m
+
 ksp.incremental=true
 ksp.useKSP2=true
+
+org.gradle.caching=true
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m
+org.gradle.parallel=true
 
 group=org.komapper
 version=0.0.1


### PR DESCRIPTION
## Summary
- Enable Gradle build caching for faster incremental builds
- Enable parallel execution to utilize multiple CPU cores
- Increase JVM heap memory from 2560m to 4096m and set max metaspace to 1024m

## Test plan
- [x] Run `./gradlew build` to verify all projects build successfully
- [x] Run `./gradlew test` to ensure all tests pass
- [ ] Verify build time improvement with clean build

🤖 Generated with [Claude Code](https://claude.ai/code)